### PR TITLE
faster powershell startup

### DIFF
--- a/wsl/Powershell-Windows.md
+++ b/wsl/Powershell-Windows.md
@@ -1,47 +1,47 @@
 # Powershell setup
 
-* Execute with *Admin* PS: `New-Item -ItemType SymbolicLink -Target $env:USERPROFILE\source\repos\dotfile\wsl\powerShell_profile.ps1 -Path $PROFILE`. The `$PROFILE` is for [Current User, Current Host](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles). The other profiles are saved in note properties of the $PROFILE variable, for example: `$PROFILE.CurrentUserAllHosts`, `$PROFILE.AllUsersAllHosts` etc.
-* To start PowerShell without profiles, use the NoProfile parameter of pwsh.exe, the program that starts PowerShell: `pwsh -NoProfile`.
+- Execute with _Admin_ PS: `New-Item -ItemType SymbolicLink -Target $env:USERPROFILE\source\repos\dotfile\wsl\powerShell_profile.ps1 -Path $PROFILE`. The `$PROFILE` is for [Current User, Current Host](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles). The other profiles are saved in note properties of the $PROFILE variable, for example: `$PROFILE.CurrentUserAllHosts`, `$PROFILE.AllUsersAllHosts` etc.
+- To start PowerShell without profiles, use the NoProfile parameter of pwsh.exe, the program that starts PowerShell: `pwsh -NoProfile`.
 
 ## oh-my-posh
 
-* [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh)  provides similar stuff with oh-my-zsh.
+- [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh) provides similar stuff with oh-my-zsh.
   if `cannot be loaded because the execution of scripts is disabled on this system.` in powershell, we need to set execution policy by `Set-ExecutionPolicy RemoteSigned`
-* use `notepad $PROFILE`  or `nvim $PROFILE` to edit options like importing modules and other customizations. Typially the location is `C:\Users\YourUserName\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
-  * if `$PROFILE` does not exist, use `new-item -type file -path $profile -force` to create.
-  * do `. $PROFILE` after change to reload the setting.
-  * example config: see the `powershell_profile.ps1` file.
+- use `notepad $PROFILE` or `nvim $PROFILE` to edit options like importing modules and other customizations. Typially the location is `C:\Users\YourUserName\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+  - if `$PROFILE` does not exist, use `new-item -type file -path $profile -force` to create.
+  - do `. $PROFILE` after change to reload the setting.
+  - example config: see the `powershell_profile.ps1` file.
 
 ## PSReadLine
 
-* [PSReadLine](https://devblogs.microsoft.com/powershell/announcing-psreadline-2-1-with-predictive-intellisense/?WT.mc_id=-blog-scottha) provides auto completion.
-  * `Install-Module PSReadLine -RequiredVersion 2.2.6 -Force`
+- [PSReadLine](https://devblogs.microsoft.com/powershell/announcing-psreadline-2-1-with-predictive-intellisense/?WT.mc_id=-blog-scottha) provides auto completion.
+  - `Install-Module PSReadLine -RequiredVersion 2.2.6 -Force`
 
 ## Z
 
-* [ZLocation](https://github.com/vors/ZLocation) for smart jump.
-  * `Install-Module ZLocation -Force`
+- [ZLocation](https://github.com/vors/ZLocation) for smart jump.
+  - `Install-Module ZLocation -Force` (can be lazy loaded by wrapping in a function)
 
 ## Terminal Icon
 
-* install module: `Install-Module -Name Terminal-Icons -Repository PSGallery`
-* add to $PROFILE: `Import-Module -Name Terminal-Icons -Force`
+- install module: `Install-Module -Name Terminal-Icons -Repository PSGallery`
+- add to $PROFILE: `Import-Module -Name Terminal-Icons -Force`
 
 ## Fzf integration using PSfzf
 
-* installation: 1. `choco install fzf -y`, 2. `Install-Module PSFzf -Force`.
-* config as above example config. [source](https://www.damirscorner.com/blog/posts/20211119-PowerShellModulesForABetterCommandLine.html)
+- installation: 1. `choco install fzf -y`, 2. `Install-Module PSFzf -Force`(can be lazy loaded by wrapping in a function)
+- config as above example config. [source](https://www.damirscorner.com/blog/posts/20211119-PowerShellModulesForABetterCommandLine.html)
 
 ## neovim
 
-* install [chocolatey](https://community.chocolatey.org/courses/installation/installing?method=install-from-powershell-v3). (admin)
-* install [neovim](https://community.chocolatey.org/packages/neovim)
-  * `choco install neovim -y`
-  * the `:echo stdpath(‘config’)` shows config path which is typially `~/AppData/Local/nvim/`. if not exist, create this directory.
-    * create the `init.vim` config file here if not exist. put vim config stuff in.
-    * the `coc.vim` config can also be placed here and referenced in the `init.vim` by: `source ~/AppData/Local/nvim/coc.vim`
-    * the `coc-settings.json` can also be placed here so that coc would load it by default/convention.
-* install [vim-plug](https://dev.to/ritikadas/using-neovim-as-an-effortless-way-to-edit-code-installation-and-setup-guide-for-windows-10-5dhc).
+- install [chocolatey](https://community.chocolatey.org/courses/installation/installing?method=install-from-powershell-v3). (admin)
+- install [neovim](https://community.chocolatey.org/packages/neovim)
+  - `choco install neovim -y`
+  - the `:echo stdpath(‘config’)` shows config path which is typially `~/AppData/Local/nvim/`. if not exist, create this directory.
+    - create the `init.vim` config file here if not exist. put vim config stuff in.
+    - the `coc.vim` config can also be placed here and referenced in the `init.vim` by: `source ~/AppData/Local/nvim/coc.vim`
+    - the `coc-settings.json` can also be placed here so that coc would load it by default/convention.
+- install [vim-plug](https://dev.to/ritikadas/using-neovim-as-an-effortless-way-to-edit-code-installation-and-setup-guide-for-windows-10-5dhc).
 
   ```powershell
     md ~\AppData\Local\nvim\autoload
@@ -55,21 +55,34 @@
     )
   ```
 
-* for `floatterm` to use latest powershell: `let g:floaterm_shell="pwsh.exe -NoLogo"`
+- for `floatterm` to use latest powershell: `let g:floaterm_shell="pwsh.exe -NoLogo"`
 
 ## commands
 
-* `ii .` -> `open .`
-* `gdr` -> `df -h`
-* `get-command` -> `which`
+- `ii .` -> `open .`
+- `gdr` -> `df -h`
+- `get-command` -> `which`
 
 ## environment variable
 
-* env var is typically defined with `$env:`, like `$env:LOCALAPPDATA` points to `$HOME\AppData\Local\`.
-* to define a tmp env var before executing the command, similar to linux, do `$env:FOO='Bar'; python .\myPythonScript`
-* to show all env vars, use Get-ChildItem, `gci env:`, or `ls env:`, or `dir env:`
-* to permanently add path to env, put `$env:Path += ";SomeRandomPath"` at the `$PROFILE` file.
+- env var is typically defined with `$env:`, like `$env:LOCALAPPDATA` points to `$HOME\AppData\Local\`.
+- to define a tmp env var before executing the command, similar to linux, do `$env:FOO='Bar'; python .\myPythonScript`
+- to show all env vars, use Get-ChildItem, `gci env:`, or `ls env:`, or `dir env:`
+- to permanently add path to env, put `$env:Path += ";SomeRandomPath"` at the `$PROFILE` file.
 
 ## Windows Server
 
-* use `start powershell` to get a new instace/window
+- use `start powershell` to get a new instace/window
+
+## Conda startup optimization
+
+- by default in the All Hosts pwsh proifle `$HOME\Documents\PowerShell\profile.ps1`, conda will init with `(& "$HOME\Miniconda3\Scripts\conda.exe" "shell.powershell" "hook") | Out-String | Invoke-Expression`.
+- use the conda-hook.ps1 script directly, which might be more efficient. You can find this script in your Conda installation directory and source it in your profile.
+
+```sh
+$condaHook = "$HOME\Miniconda3\shell\condabin\conda-hook.ps1"
+if (Test-Path $condaHook) {
+    . $condaHook
+}
+
+```

--- a/wsl/powershell_profile.ps1
+++ b/wsl/powershell_profile.ps1
@@ -1,81 +1,100 @@
 # for Windows server with choco install, manually add path.
 # $env:Path += ";C:\Tools\neovim\nvim-win64\bin\;C:\ProgramData\chocolatey\bin\;C:\Program Files\GIT\bin;C:\Program Files\nodejs"
 
-oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\powerlevel10k_rainbow.omp.json" | Invoke-Expression
+# Register idle event to load Terminal-Icons
+$null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
 
-Set-PSReadLineOption -PredictionSource History
+    Import-Module Terminal-Icons
+
+    Set-PSReadLineOption -PredictionSource History
 
 # pwsh vi mode
-Set-PSReadlineOption -EditMode vi
-function OnViModeChange {
-    if ($args[0] -eq 'Command') {
-        # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "`e[1 q"
-    } else {
-        # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "`e[5 q"
-    }
-}
-Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
+		Set-PSReadlineOption -EditMode vi
+		function OnViModeChange {
+    		if ($args[0] -eq 'Command') {
+        		# Set the cursor to a blinking block.
+        		Write-Host -NoNewLine "`e[1 q"
+    		} else {
+        		# Set the cursor to a blinking line.
+        		Write-Host -NoNewLine "`e[5 q"
+    		}
+		}
+		Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
 
 # set nvim as default editor for visual mode.
-Set-Item Env:EDITOR nvim
+		Set-Item Env:EDITOR nvim
 
 # use `ctrl+[` to exit from Edit mode to Command mode
-Set-PSReadLineKeyHandler -Chord 'Ctrl+Oem4' -Function ViCommandMode
+		Set-PSReadLineKeyHandler -Chord 'Ctrl+Oem4' -Function ViCommandMode
 
-Import-Module ZLocation
-Import-Module -Name Terminal-Icons
-Import-Module PSFzf
+
 # Override PSReadLine's history search
-Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+p' `
-	-PSReadlineChordReverseHistory 'Ctrl+r'
+		Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+p' `
+			-PSReadlineChordReverseHistory 'Ctrl+r'
 # Override default tab completion
-Set-PSReadLineKeyHandler -Key Tab -ScriptBlock { Invoke-FzfTabCompletion }
+		Set-PSReadLineKeyHandler -Key Tab -ScriptBlock { Invoke-FzfTabCompletion }
 # open file with neovim/notepad
-Function ov { Get-ChildItem . -Recurse -Attributes !Directory | Invoke-Fzf | % { nvim $_ } }
-Function on { Get-ChildItem . -Recurse -Attributes !Directory | Invoke-Fzf | % { notepad $_ } }
+		Function ov { Get-ChildItem . -Recurse -Attributes !Directory | Invoke-Fzf | % { nvim $_ } }
+		Function on { Get-ChildItem . -Recurse -Attributes !Directory | Invoke-Fzf | % { notepad $_ } }
 
 # Import the Chocolatey Profile that contains the necessary code to enable
 # tab-completions to function for `choco`.
 # Be aware that if you are missing these lines from your profile, tab completion
 # for `choco` will not function.
 # See https://ch0.co/tab-completion for details.
-$ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
-if (Test-Path($ChocolateyProfile)) {
-	Import-Module "$ChocolateyProfile"
-}
+		$ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+		if (Test-Path($ChocolateyProfile)) {
+			Import-Module "$ChocolateyProfile"
+		}
 
-Set-Alias -Name open -Value ii
-Set-Alias -Name which -Value get-command
-Set-Alias -Name vi -Value nvim
-Set-Alias -Name touch -Value new-item
-Set-Alias -Name grep -Value findstr
+		Set-Alias -Name open -Value ii
+		Set-Alias -Name which -Value get-command
+		Set-Alias -Name vi -Value nvim
+		Set-Alias -Name touch -Value new-item
+		Set-Alias -Name grep -Value findstr
 
 # `ll` with eza in wsl in available
-Function ll {
-	$target = '.'
-	if ($args[0]) {
-		$target = $args[0] -replace "`\\", "`/"
-	}
-	wsl eza -al --group --icons --sort=modified $target
-}
-Function ev { nvim $env:LOCALAPPDATA\nvim\init.vim }
-Function gs { git status }
-Function gd { git diff }
+		Function ll {
+			$target = '.'
+			if ($args[0]) {
+				$target = $args[0] -replace "`\\", "`/"
+			}
+			wsl eza -al --group --icons --sort=modified $target
+		}
+		Function ev { nvim $env:LOCALAPPDATA\nvim\init.vim }
+		Function gs { git status }
+		Function gd { git diff }
 # remove PowerShell default alias
-Remove-Item -Path alias:gl -Force
-function gl { git pull }
-Remove-Item -Path alias:gp -Force
-function gp { git push }
+		Remove-Item -Path alias:gl -Force
+		function gl { git pull }
+		Remove-Item -Path alias:gp -Force
+		function gp { git push }
 
 # ctrl+f to accept suggestion
-Set-PSReadLineKeyHandler -Chord "Ctrl+f" -ScriptBlock {
-	[Microsoft.PowerShell.PSConsoleReadLine]::AcceptSuggestion()
-	[Microsoft.PowerShell.PSConsoleReadLine]::EndOfLine()
-}
-Set-PSReadLineOption -HistorySearchCursorMovesToEnd
-Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
-Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
+		Set-PSReadLineKeyHandler -Chord "Ctrl+f" -ScriptBlock {
+			[Microsoft.PowerShell.PSConsoleReadLine]::AcceptSuggestion()
+			[Microsoft.PowerShell.PSConsoleReadLine]::EndOfLine()
+		}
+		Set-PSReadLineOption -HistorySearchCursorMovesToEnd
+		Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
+		Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
 # ctrl+e to move forward word
-Set-PSReadLineKeyHandler -chord 'Ctrl+e' -Function ForwardWord
+		Set-PSReadLineKeyHandler -chord 'Ctrl+e' -Function ForwardWord
+
+    Unregister-Event -SourceIdentifier PowerShell.OnIdle
+}
+
+function z {
+    Import-Module ZLocation
+    Remove-Item -Path Function:z
+    z @args
+}
+function fzf {
+    Import-Module PSFzf
+    Remove-Item -Path Function:fzf
+    fzf @args
+}
+
+oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\powerlevel10k_rainbow.omp.json" | Invoke-Expression
+
+


### PR DESCRIPTION
start up time goes from `7s` to `1s`

1. use `Register-EngineEvent` to run init commands and modules need in startup like `termial-icon` in the background

2. add doc for use `conda-hook.ps1` script directly instead of calling conda.exe at pwsh startup which takes almost 3 seconds

3. lazy load `z` and `fzf` module by wrapping into function so import on when first time usage.
