### PR TITLE
Add Python DAP config

### DIFF
--- a/.config/nvim/lua/plugins/mason.lua
+++ b/.config/nvim/lua/plugins/mason.lua
@@ -17,9 +17,6 @@ return {
         -- install formatters
         "stylua",
 
-        -- install debuggers
-        "debugpy",
-
         -- install any other package
         "tree-sitter-cli",
       },

--- a/.config/nvim/lua/plugins/python.lua
+++ b/.config/nvim/lua/plugins/python.lua
@@ -1,0 +1,29 @@
+---@type LazySpec
+return {
+  {
+    "jay-babu/mason-nvim-dap.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed or {}, { "python" })
+      opts.handlers = opts.handlers or {}
+      opts.handlers.python = function() end
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed or {}, { "debugpy" })
+    end,
+  },
+  {
+    "mfussenegger/nvim-dap-python",
+    ft = "python",
+    dependencies = { "mfussenegger/nvim-dap" },
+    config = function()
+      local debugpy = vim.fn.exepath "debugpy-adapter"
+      if debugpy == "" then debugpy = vim.fn.exepath "uv" end
+      if debugpy == "" then debugpy = vim.fn.exepath "python3" end
+      if debugpy == "" then debugpy = vim.fn.exepath "python" end
+      require("dap-python").setup(debugpy)
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- add Python-specific DAP setup using nvim-dap-python
- ensure debugpy is requested through Mason tooling
- remove duplicate debugpy entry from the disabled Mason config

## Test
- nvim --headless "+set filetype=python" "+lua require('lazy').load({ plugins = { 'nvim-dap-python' } }); local dap = require('dap'); if not dap.adapters.python then error('missing python dap adapter') end; print('python dap adapter ok')" +qa